### PR TITLE
docs: Makefile, README site_url, generator mkdocs site_url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+# SpecHub convenience targets
+
+.PHONY: build validate docs serve all
+
+build:
+	python3 specs/_build/build.py
+
+validate:
+	python3 trace_validator.py
+
+docs:
+	python3 docs/generate_docs.py
+
+serve:
+	mkdocs serve
+
+all: build validate docs

--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ python3 specs/_build/build.py && python3 trace_validator.py
 - `05_HIG_Pattern_selection_v1.json`
 - `06_Contextual_UX_Guidelines_v1.json`
 
+## Локальный запуск SpecHub (портал)
+
+Требуется: graphviz, Python venv.
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+pip install mkdocs mkdocs-material jinja2 pydot graphviz markdownify
+python3 specs/_build/build.py
+python3 trace_validator.py
+python3 docs/generate_docs.py
+mkdocs serve
+```
+
+Откройте http://127.0.0.1:8000 — на главной будут обе диаграммы.
+
+## Источники vs Артефакты
+
+- Источники спецификаций: `specs/**`
+- Артефакты монолитов: `specs/_build/*.json`
+- Генерируемая документация: `docs/**`, диаграммы: `docs/_media/*.svg`
+
+В страницах добавлены ссылки "✏️ Edit source" на соответствующие файлы под `specs/**`.
+
 ## Что проверяет валидатор
 - Согласованность ссылок между PRD/CJM/UserFlow/UserStories/UX/CTXUX.
 - Guard-выражения в рёбрах User Flow: только допустимые операторы, строковые литералы в кавычках.


### PR DESCRIPTION
Small follow-up to add:
- Makefile convenience targets
- README local SpecHub run instructions
- mkdocs site_url for Pages canonical (and generator writes it)
