### PR TITLE
ci(pages): fix Pages deploy wiring

### DIFF
--- a/.github/workflows/spechub.yml
+++ b/.github/workflows/spechub.yml
@@ -4,12 +4,22 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pages: write
       id-token: write
 
@@ -48,6 +58,14 @@ jobs:
       - name: Build MkDocs site
         run: |
           mkdocs build --strict
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
 
       - name: Link check (internal only)
         run: |
@@ -99,14 +117,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './site'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fix Pages deploy: configure-pages + upload-pages-artifact in build job; simplified deploy job to only deploy artifact to environment github-pages. Also added top-level permissions and concurrency.
