### PR TITLE
ci(link-check): use lychee action; strict generation fixes already merged

### DIFF
--- a/.github/workflows/spechub.yml
+++ b/.github/workflows/spechub.yml
@@ -68,23 +68,19 @@ jobs:
           path: ./site
 
       - name: Link check (internal only)
-        run: |
-          docker run --rm -v "$PWD/site":/site ghcr.io/lycheeverse/lychee:latest \
-            --offline \
-            --no-progress \
-            --timeout 10 \
-            --verbose \
-            "/site/**/*.html"
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: --offline --no-progress --timeout 10 --verbose ./site/**/*.html
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Link check (external; warnings only)
+        uses: lycheeverse/lychee-action@v1
         continue-on-error: true
-        run: |
-          docker run --rm -v "$PWD/site":/site ghcr.io/lycheeverse/lychee:latest \
-            --no-progress \
-            --timeout 10 \
-            --verbose \
-            --exclude "https://json-schema.org,https://github.com" \
-            "/site/**/*.html"
+        with:
+          args: --no-progress --timeout 10 --verbose --exclude "https://json-schema.org,https://github.com" ./site/**/*.html
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Markdown lint (warnings only)
         continue-on-error: true


### PR DESCRIPTION
Switch link-check from GHCR docker image to lycheeverse/lychee-action to avoid registry auth/pull issues in Actions. Preserves behavior:
- Internal (offline) links: fail build
- External links: warnings only; timeout 10s; exclude json-schema.org and github.com

Pages deploy wiring already fixed in previous PR; this PR ensures link-check won't block due to image pull errors.
